### PR TITLE
feat: use lint-content script to lint YAML files

### DIFF
--- a/lib/main.js
+++ b/lib/main.js
@@ -32,6 +32,7 @@ exports.run = void 0;
 const core = __importStar(require("@actions/core"));
 const github = __importStar(require("@actions/github"));
 const tmp = __importStar(require("tmp"));
+const fs = __importStar(require("fs"));
 const check_1 = require("./check");
 const input = __importStar(require("./input"));
 const execa = require('execa');
@@ -45,7 +46,9 @@ function run(actionInput) {
     var _a, _b;
     return __awaiter(this, void 0, void 0, function* () {
         const startedAt = new Date().toISOString();
-        const alertResp = yield execa('vale', actionInput.args);
+        const command = fs.existsSync('./scripts/lint-content') ? './scripts/lint-content' : 'vale';
+        core.info(`Using command: ${command}`);
+        const alertResp = yield execa(command, actionInput.args);
         let runner = new check_1.CheckRunner();
         let sha = github.context.sha;
         if ((_b = (_a = github.context.payload.pull_request) === null || _a === void 0 ? void 0 : _a.head) === null || _b === void 0 ? void 0 : _b.sha) {

--- a/src/main.ts
+++ b/src/main.ts
@@ -1,6 +1,7 @@
 import * as core from '@actions/core';
 import * as github from '@actions/github';
 import * as tmp from 'tmp';
+import * as fs from 'fs';
 
 import {CheckRunner} from './check';
 import * as input from './input';
@@ -16,7 +17,10 @@ const {GITHUB_TOKEN, GITHUB_WORKSPACE} = process.env;
 
 export async function run(actionInput: input.Input): Promise<void> {
   const startedAt = new Date().toISOString();
-  const alertResp = await execa('vale', actionInput.args);
+
+  const command = fs.existsSync('./scripts/lint-content') ? './scripts/lint-content' : 'vale';
+  core.info(`Using command: ${command}`)
+  const alertResp = await execa(command, actionInput.args);
 
   let runner = new CheckRunner();
 


### PR DESCRIPTION
This forwards calls to vale to the `./scripts/lint-content` executable if it exists. Doing this only when it exists allows for backwards compatibility for branches that don't have this script yet, without them having to rebase their branches.