### PR TITLE
feat: wrap quotes around filenames

### DIFF
--- a/lib/input.js
+++ b/lib/input.js
@@ -106,7 +106,9 @@ function get(tmp, tok, dir) {
         const files = core.getInput('files');
         if (core.getInput('onlyAnnotateModifiedLines') != 'false' ||
             files == '__onlyModified') {
-            args = args.concat(git_1.modifiedFilesInPR());
+            // We need to wrap all filenames in quotes to prevent errors.
+            const modifiedFiles = git_1.modifiedFilesInPR().map((f) => { return `"${f}"`; });
+            args = args.concat(modifiedFiles);
         }
         else if (files == 'all') {
             args.push('.');

--- a/src/input.ts
+++ b/src/input.ts
@@ -98,7 +98,9 @@ export async function get(tmp: any, tok: string, dir: string): Promise<Input> {
     core.getInput('onlyAnnotateModifiedLines') != 'false' ||
     files == '__onlyModified'
   ) {
-    args = args.concat(modifiedFilesInPR());
+    // We need to wrap all filenames in quotes to prevent errors.
+    const modifiedFiles = modifiedFilesInPR().map((f) => { return `"${f}"` })
+    args = args.concat(modifiedFiles);
   } else if (files == 'all') {
     args.push('.');
   } else if (fs.existsSync(path.resolve(dir, files))) {


### PR DESCRIPTION
This PR wraps quotes around the filenames to lint. This is to prevent errors when a file doesn't exist, or has odd characters in its name, such as `sorbet/rbi/sorbet-typed/lib/rubocop/>=1.8/rubocop.rbi`.